### PR TITLE
Use Travis to set the Cache-Control header on S3 uploads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ deploy:
   bucket: www.renzolucioni.com
   skip_cleanup: true
   local_dir: output
+  cache_control: "max-age=21600"
 after_deploy:
   - aws configure set preview.cloudfront true
   - aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "/*"


### PR DESCRIPTION
When the origin (S3) adds a Cache-Control max-age directive to objects, CloudFront caches them for the lesser of the value of the Cache-Control max-age directive or the value of the CloudFront maximum TTL.